### PR TITLE
Active Record: automatic bulk method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,8 @@ gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"
 gem "minitest-sprint"
+
+gem "debug"
+
+gem "activerecord"
+gem "sqlite3"

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,8 @@ gem "minitest-sprint"
 
 gem "debug"
 
-gem "activerecord"
+# Fetch latest Active Job to test `ActiveJob.perform_all_later`
+gem "rails", github: "rails/rails"
+
+# gem "activerecord" # We get this from Rails above ^
 gem "sqlite3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,103 @@
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 31052d0e518b9da103eea2f79d250242ed1e3705
+  specs:
+    actioncable (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      activejob (= 7.1.0.alpha)
+      activerecord (= 7.1.0.alpha)
+      activestorage (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      actionview (= 7.1.0.alpha)
+      activejob (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.0.alpha)
+      actionview (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      activerecord (= 7.1.0.alpha)
+      activestorage (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      globalid (>= 0.3.6)
+    activemodel (7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+    activerecord (7.1.0.alpha)
+      activemodel (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      timeout (>= 0.4.0)
+    activestorage (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      activejob (= 7.1.0.alpha)
+      activerecord (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      marcel (~> 1.0)
+    activesupport (7.1.0.alpha)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    rails (7.1.0.alpha)
+      actioncable (= 7.1.0.alpha)
+      actionmailbox (= 7.1.0.alpha)
+      actionmailer (= 7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      actiontext (= 7.1.0.alpha)
+      actionview (= 7.1.0.alpha)
+      activejob (= 7.1.0.alpha)
+      activemodel (= 7.1.0.alpha)
+      activerecord (= 7.1.0.alpha)
+      activestorage (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      bundler (>= 1.15.0)
+      railties (= 7.1.0.alpha)
+    railties (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+
 PATH
   remote: .
   specs:
@@ -7,23 +107,19 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activejob (7.0.4)
-      activesupport (= 7.0.4)
-      globalid (>= 0.3.6)
-    activemodel (7.0.4)
-      activesupport (= 7.0.4)
-    activerecord (7.0.4)
-      activemodel (= 7.0.4)
-      activesupport (= 7.0.4)
-    activesupport (7.0.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
     concurrent-ruby (1.1.10)
+    connection_pool (2.4.1)
+    crass (1.0.6)
+    date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    drb (2.1.1)
+      ruby2_keywords
+    erubi (1.12.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -32,22 +128,71 @@ GEM
     irb (1.8.0)
       rdoc (~> 6.5)
       reline (>= 0.3.6)
+    loofah (2.21.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    mini_mime (1.1.5)
     minitest (5.16.3)
     minitest-sprint (1.2.2)
       path_expander (~> 1.1)
+    mutex_m (0.1.2)
+    net-imap (0.3.7)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.9)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     path_expander (1.1.1)
     psych (5.1.0)
       stringio
+    racc (1.7.1)
+    rack (3.0.8)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
     rake (13.0.6)
     rdoc (6.5.0)
       psych (>= 4.0.0)
     reline (0.3.8)
       io-console (~> 0.5)
+    ruby2_keywords (0.0.5)
     sqlite3 (1.6.4-arm64-darwin)
     sqlite3 (1.6.4-x86_64-linux)
     stringio (3.0.8)
+    thor (1.2.2)
+    timeout (0.4.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    webrick (1.8.1)
+    websocket-driver (0.7.6)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   arm64-darwin-20
@@ -56,10 +201,10 @@ PLATFORMS
 
 DEPENDENCIES
   active_job-performs!
-  activerecord
   debug
   minitest (~> 5.0)
   minitest-sprint
+  rails!
   rake (~> 13.0)
   sqlite3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,33 +10,58 @@ GEM
     activejob (7.0.4)
       activesupport (= 7.0.4)
       globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
     activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     concurrent-ruby (1.1.10)
+    debug (1.8.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.8.0)
+      rdoc (~> 6.5)
+      reline (>= 0.3.6)
     minitest (5.16.3)
     minitest-sprint (1.2.2)
       path_expander (~> 1.1)
     path_expander (1.1.1)
+    psych (5.1.0)
+      stringio
     rake (13.0.6)
+    rdoc (6.5.0)
+      psych (>= 4.0.0)
+    reline (0.3.8)
+      io-console (~> 0.5)
+    sqlite3 (1.6.4-arm64-darwin)
+    sqlite3 (1.6.4-x86_64-linux)
+    stringio (3.0.8)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
   active_job-performs!
+  activerecord
+  debug
   minitest (~> 5.0)
   minitest-sprint
   rake (~> 13.0)
+  sqlite3
 
 BUNDLED WITH
-   2.3.21
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ class Post < ActiveRecord::Base
     end
   end
 
+  # On Rails 7.1, where `ActiveJob.perform_all_later` exists, we also generate
+  # a bulk method to enqueue many jobs at once. So you can do this:
+  #
+  #   Post.unpublished.in_batches.each(&:publish_later_bulk)
+  def self.publish_later_bulk
+    ActiveJob.perform_all_later all.map { PublishJob.new(_1) }
+  end
+
   # We generate `publish_later` to wrap the job execution.
   def publish_later(*arguments, **options)
     PublishJob.perform_later(self, *arguments, **options)

--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -46,6 +46,12 @@ module ActiveJob::Performs
         end
       RUBY
 
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1 if respond_to?(:all)
+        def self.#{method}_later#{suffix}_bulk
+          all.each(&:#{method}_later#{suffix})
+        end
+      RUBY
+
       class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def #{method}_later#{suffix}(*arguments, **options)
           #{job}.scoped_by_wait(self).perform_later(self, *arguments, **options)

--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+module ActiveJob::ActiveRecord; end
+class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
+  setup do
+    Invoice.insert_all [{}, {}, {}, {}, {}]
+  end
+
+  test "performs individually" do
+    assert_performed_with job: Invoice::DeliverReminderJob, args: [Invoice.first] do
+      Invoice.first.deliver_reminder_later
+    end
+    perform_enqueued_jobs
+
+    assert Invoice.first.reminded_at
+  end
+
+  test "performs bulk" do
+    assert_enqueued_jobs 5, only: Invoice::DeliverReminderJob do
+      Invoice.all.deliver_reminder_later_bulk
+    end
+    perform_enqueued_jobs
+
+    assert_equal 5, Invoice.pluck(:reminded_at).compact.size
+  end
+
+  test "performs bulk on relation" do
+    assert_enqueued_jobs 3, only: Invoice::DeliverReminderJob do
+      Invoice.where(id: Invoice.first(3)).deliver_reminder_later_bulk
+    end
+    perform_enqueued_jobs
+
+    assert_equal 3, Invoice.pluck(:reminded_at).compact.size
+  end
+end

--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -24,6 +24,15 @@ class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
     assert_equal 5, Invoice.pluck(:reminded_at).compact.size
   end
 
+  test "performs bulk in_batches" do
+    assert_enqueued_jobs 5, only: Invoice::DeliverReminderJob do
+      Invoice.in_batches(of: 2).each(&:deliver_reminder_later_bulk)
+    end
+    perform_enqueued_jobs
+
+    assert_equal 5, Invoice.pluck(:reminded_at).compact.size
+  end
+
   test "performs bulk on relation" do
     assert_enqueued_jobs 3, only: Invoice::DeliverReminderJob do
       Invoice.where(id: Invoice.first(3)).deliver_reminder_later_bulk

--- a/test/active_job/test_performs.rb
+++ b/test/active_job/test_performs.rb
@@ -3,8 +3,6 @@
 require "test_helper"
 
 class ActiveJob::TestPerforms < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
   setup do
     Post::Publisher.performed = false
     @publisher = Post::Publisher.new(1)


### PR DESCRIPTION
In Rails 7.1, `ActiveJob.perform_all_later` will push out jobs in bulk to a queue, and we can make that nicer for our jobs.

Running the below now automatically adds a `deliver_reminder_later_bulk` to `Invoice`:

```ruby
class Invoice < ActiveRecord::Base
  performs def deliver_reminder
    touch :reminded_at
  end
end
```

So users can do `Invoice.all.deliver_reminder_later_bulk` or `Invoice.overdue.in_batches.each(&:deliver_reminder_later_bulk)`.

Ref: #4