### PR TITLE
Fix `private performs` marking on immediate version too

### DIFF
--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -59,6 +59,8 @@ module ActiveJob::Performs
           #{job}.scoped_by_wait(self).perform_later(self, *arguments, **options)
         end
       RUBY
+
+      [method, :"#{method}_later#{suffix}"] # Ensure `private performs :some_method` privates both names.
     end
   end
 

--- a/test/active_job/test_performs.rb
+++ b/test/active_job/test_performs.rb
@@ -26,6 +26,7 @@ class ActiveJob::TestPerforms < ActiveSupport::TestCase
   end
 
   test "supports private methods" do
+    assert_includes Post::Publisher.private_instance_methods, :private_method
     assert_includes Post::Publisher.private_instance_methods, :private_method_later
 
     assert_output "private_method\n" do


### PR DESCRIPTION
`private performs :some_method` should make both `:some_method` and `:some_method_later` private. But that only works if we return an array with both method names.