### PR TITLE
Document and test a pattern for app-wide methods

### DIFF
--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -2,6 +2,42 @@ require "test_helper"
 
 module ActiveJob::ActiveRecord; end
 class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
+  setup { @invoice = Invoice.create! }
+
+  test "touch_later" do
+    assert_changes -> { @invoice.reload.updated_at } do
+      assert_performed_with job: ApplicationRecord::TouchJob, args: [@invoice] do
+        @invoice.touch_later
+      end
+    end
+
+    time = 5.minutes.from_now
+    assert_changes -> { @invoice.reload.reminded_at }, to: time do
+      assert_performed_with job: ApplicationRecord::TouchJob, args: [@invoice, :reminded_at, time: time] do
+        @invoice.touch_later :reminded_at, time: time
+      end
+    end
+  end
+
+  test "update_later" do
+    time = 5.minutes.from_now
+    assert_changes -> { @invoice.reload.reminded_at }, to: time do
+      assert_performed_with job: ApplicationRecord::UpdateJob, args: [@invoice, reminded_at: time] do
+        @invoice.update_later reminded_at: time
+      end
+    end
+  end
+
+  test "destroy_later" do
+    assert_enqueued_with job: ApplicationRecord::DestroyJob, args: [@invoice] do
+      @invoice.destroy_later
+    end
+    perform_enqueued_jobs
+    assert_raise(ActiveRecord::RecordNotFound) { @invoice.reload }
+  end
+end
+
+class ActiveJob::ActiveRecord::TestPerformsBulk < ActiveSupport::TestCase
   setup do
     Invoice.insert_all [{}, {}, {}, {}, {}]
   end

--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -11,7 +11,7 @@ class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
       end
     end
 
-    time = 5.minutes.from_now.utc
+    time = Time.now.utc.change(usec: 0)
     assert_changes -> { @invoice.reload.reminded_at }, to: time do
       assert_performed_with job: ApplicationRecord::TouchJob, args: [@invoice, :reminded_at, time: time] do
         @invoice.touch_later :reminded_at, time: time
@@ -20,7 +20,7 @@ class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
   end
 
   test "update_later" do
-    time = 5.minutes.from_now.utc
+    time = Time.now.utc.change(usec: 0)
     assert_changes -> { @invoice.reload.reminded_at }, to: time do
       assert_performed_with job: ApplicationRecord::UpdateJob, args: [@invoice, reminded_at: time] do
         @invoice.update_later reminded_at: time

--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -11,7 +11,7 @@ class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
       end
     end
 
-    time = 5.minutes.from_now
+    time = 5.minutes.from_now.utc
     assert_changes -> { @invoice.reload.reminded_at }, to: time do
       assert_performed_with job: ApplicationRecord::TouchJob, args: [@invoice, :reminded_at, time: time] do
         @invoice.touch_later :reminded_at, time: time
@@ -20,7 +20,7 @@ class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
   end
 
   test "update_later" do
-    time = 5.minutes.from_now
+    time = 5.minutes.from_now.utc
     assert_changes -> { @invoice.reload.reminded_at }, to: time do
       assert_performed_with job: ApplicationRecord::UpdateJob, args: [@invoice, reminded_at: time] do
         @invoice.update_later reminded_at: time

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,9 +23,17 @@ ActiveRecord::Schema.define do
   end
 end
 
-class Invoice < ActiveRecord::Base
+class ApplicationRecord < ActiveRecord::Base
   include GlobalID::Identification
 
+  self.abstract_class = true
+
+  performs :touch,   queue_as: "active_record.touch"
+  performs :update,  queue_as: "active_record.update"
+  performs :destroy, queue_as: "active_record.destroy"
+end
+
+class Invoice < ApplicationRecord
   performs :deliver_reminder!
   def deliver_reminder!
     touch :reminded_at


### PR DESCRIPTION
You can do this on `ApplicationRecord`:

```ruby
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  # We're passing specific queues for monitoring, but you may not need or want them.
  performs :touch,   queue_as: "active_record.touch"
  performs :update,  queue_as: "active_record.update"
  performs :destroy, queue_as: "active_record.destroy"
end
```