### PR TITLE
Allow conditional enqueues on instance level `_later` methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ Additionally, in case the job is meant to be internal to the object, `performs :
 
 E.g. `private performs :some_method` will generate a private `some_method_later` method.
 
+#### Overriding the generated instance `_later` method
+
+The instance level `_later` methods, like `publish_later` above, are generated into an included module. So in case you have a condition where you'd like to prevent the enqueue, you can override the method and call `super`:
+
+```ruby
+class Post < ApplicationRecord
+  performs def publish
+    # …
+  end
+  def publish_later = some_condition? && super
+end
+```
+
 ### Usage with `ActiveRecord::AssociatedObject`
 
 The [`ActiveRecord::AssociatedObject`](https://github.com/kaspth/active_record-associated_object) gem also implements `GlobalID::Identification`, so you can do this too:

--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -54,7 +54,7 @@ module ActiveJob::Performs
         RUBY
       end
 
-      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+      performs_later_methods.class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def #{method}_later#{suffix}(*arguments, **options)
           #{job}.scoped_by_wait(self).perform_later(self, *arguments, **options)
         end
@@ -72,6 +72,10 @@ module ActiveJob::Performs
     def apply_performs_to(job_class, **configs, &block)
       configs.each { job_class.public_send(_1, _2) }
       job_class.class_exec(&block) if block_given?
+    end
+
+    def performs_later_methods
+      @performs_later_methods ||= Module.new.tap { include _1 }
     end
 end
 

--- a/test/active_job/test_performs.rb
+++ b/test/active_job/test_performs.rb
@@ -55,4 +55,13 @@ class ActiveJob::TestPerforms < ActiveSupport::TestCase
       perform_enqueued_jobs
     end
   end
+
+  test "allows overriding later methods with conditions and call super" do
+    @publisher.skip_publish_later = true
+
+    assert_no_enqueued_jobs only: Post::Publisher::PublishJob do
+      @publisher.publish_later
+    end
+    refute Post::Publisher.performed
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,8 @@ class Post::Publisher < Base
   def publish
     self.class.performed = true
   end
+  attr_accessor :skip_publish_later
+  def publish_later = skip_publish_later || super
 
   def retract(reason:)
     puts reason


### PR DESCRIPTION
The instance level `_later` methods, like `publish_later` above, are now generated into an included module. So in case you have a condition where you'd like to prevent the enqueue, you can override the method and call `super`:

```ruby
class Post < ApplicationRecord
  performs def publish
    # …
  end
  def publish_later = some_condition? && super
end
```