### PR TITLE
Add `_later_bulk` methods on non-Active Record objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ class Post < ActiveRecord::Base
   # a bulk method to enqueue many jobs at once. So you can do this:
   #
   #   Post.unpublished.in_batches.each(&:publish_later_bulk)
+  #
+  # Or pass in a subset of posts as an argument:
+  #
+  #   Post.publish_later_bulk Post.unpublished
   def self.publish_later_bulk
     ActiveJob.perform_all_later all.map { PublishJob.new(_1) }
   end
@@ -256,7 +260,7 @@ end
 
 ### Usage with `ActiveRecord::AssociatedObject`
 
-The [`ActiveRecord::AssociatedObject`](https://github.com/kaspth/active_record-associated_object) gem also implements `GlobalID::Identification`, so you can do this too:
+The [`ActiveRecord::AssociatedObject`](https://github.com/kaspth/active_record-associated_object) gem also implements `GlobalID::Identification`, so you use `performs` exactly like you would on Active Records:
 
 ```ruby
 class Post::Publisher < ActiveRecord::AssociatedObject
@@ -275,6 +279,11 @@ class Post::Publisher < ActiveRecord::AssociatedObject
   end
 end
 ```
+
+> [!NOTE]
+> There's one difference with Active Record: you must pass in a set to `_later_bulk` methods. Like so:
+>
+> `Post::Publisher.publish_later_bulk Post::Publisher.first(10)`
 
 ### Passing `wait` to `performs`
 

--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -46,10 +46,10 @@ module ActiveJob::Performs
         end
       RUBY
 
-      if ActiveJob.respond_to?(:perform_all_later) && respond_to?(:all)
+      if ActiveJob.respond_to?(:perform_all_later)
         class_eval <<~RUBY, __FILE__, __LINE__ + 1
-          def self.#{method}_later_bulk#{suffix}
-            ActiveJob.perform_all_later all.map { #{job}.scoped_by_wait(_1).new(_1) }
+          def self.#{method}_later_bulk#{suffix}(set#{" = all" if respond_to?(:all)})
+            ActiveJob.perform_all_later set.map { #{job}.scoped_by_wait(_1).new(_1) }
           end
         RUBY
       end

--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -60,6 +60,15 @@ class ActiveJob::ActiveRecord::TestPerformsBulk < ActiveSupport::TestCase
     assert_equal 5, Invoice.pluck(:reminded_at).compact.size
   end
 
+  test "performs bulk as an argument" do
+    assert_enqueued_jobs 5, only: Invoice::DeliverReminderJob do
+      Invoice.deliver_reminder_later_bulk! Invoice.all
+    end
+    perform_enqueued_jobs
+
+    assert_equal 5, Invoice.pluck(:reminded_at).compact.size
+  end
+
   test "performs bulk in_batches" do
     assert_enqueued_jobs 5, only: Invoice::DeliverReminderJob do
       Invoice.in_batches(of: 2).each(&:deliver_reminder_later_bulk!)

--- a/test/active_job/test_performs.rb
+++ b/test/active_job/test_performs.rb
@@ -25,6 +25,20 @@ class ActiveJob::TestPerforms < ActiveSupport::TestCase
     assert Post::Publisher.performed
   end
 
+  test "active job integration bulk method" do
+    assert_performed_with job: Post::Publisher::PublishJob, args: [ @publisher ], queue: "important" do
+      Post::Publisher.publish_later_bulk [ @publisher ]
+    end
+
+    assert Post::Publisher.performed
+  end
+
+  test "active job integration bulk method raises without argument" do
+    assert_raise ArgumentError do
+      Post::Publisher.publish_later_bulk
+    end
+  end
+
   test "supports private methods" do
     assert_includes Post::Publisher.private_instance_methods, :private_method
     assert_includes Post::Publisher.private_instance_methods, :private_method_later


### PR DESCRIPTION
Having a `_later_bulk` methods on non-Active Records can still be pretty nifty, so we should allow that.

Then if we're on Active Records we can default to `all` records if no argument is passed, but we can support passing in a subset directly too.

Then on non-Active Records, we can require the argument.