### PR TITLE
Prefer setter methods for configuration if they exist.

### DIFF
--- a/test/active_job/test_performs.rb
+++ b/test/active_job/test_performs.rb
@@ -50,6 +50,10 @@ class ActiveJob::TestPerforms < ActiveSupport::TestCase
     end
   end
 
+  test "can assign queue_adapter" do
+    assert_equal "inline", Post::Publisher::RetractJob.queue_adapter_name
+  end
+
   test "wait is forwarded" do
     assert_enqueued_with job: Post::Publisher::RetractJob, args: [ @publisher, reason: "Some reason" ], at: 5.minutes.from_now do
       @publisher.retract_later reason: "Some reason"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,7 +58,7 @@ class Post::Publisher < Base
     retry_on StandardError, wait: :polynomially_longer
   end
 
-  performs :retract, wait: 5.minutes
+  performs :retract, wait: 5.minutes, queue_adapter: :inline
   performs :social_media_boost!, wait_until: -> publisher { publisher.next_funnel_step_happens_at }
 
   def next_funnel_step_happens_at


### PR DESCRIPTION
Assigning a queue happens via `queue_as :default`, but assigning a queue adapter happens via `self.queue_adapter= :sidekiq`.

So for us to support both we can detect and prefer a setter looking method but fall back to a getter.

Here, I'm also refactoring our internal `wait` and `wait_until` support to not assign via a getter looking method too.

Fixes https://github.com/kaspth/active_job-performs/issues/17