### PR TITLE
Let wait: and wait_until: accept a symbol

### DIFF
--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -12,11 +12,15 @@ module ActiveJob::Performs
     end
 
     def wait_until=(value)
+      @wait_until_symbol = value if value.is_a?(Symbol)
       @wait_until = value.respond_to?(:call) ? value : proc { value }
     end
 
     def scoped_by_wait(record)
-      if waits = { wait: wait&.call(record), wait_until: wait_until&.call(record) }.compact and waits.any?
+      scoped_wait = wait&.call(record)
+      scoped_wait_until = @wait_until_symbol ? record.public_send(@wait_until_symbol) : wait_until&.call(record)
+
+      if waits = { wait: scoped_wait, wait_until: scoped_wait_until }.compact and waits.any?
         set(waits)
       else
         self


### PR DESCRIPTION
This PR is more to start a feature discussion than to actually merge this code :)

I use `performs` a lot in my codebase, often with `wait:` and `wait_until:`, at times like this:

```ruby
performs :notify_customer, wait: 1.second
```

but more commonly like this:

```ruby
performs :send_offer, wait_until: ->(nomination) { nomination.earliest_operating_time }
```

In other words, the waiting time is dictated by a method that belongs to the same record.

---

My feature proposal is to be able to rewrite the last example like this:

```ruby
performs :send_offer, wait_until: :earliest_operating_time
```

The (terrible) code in this commit is just to prove that it can be done. @kaspth is this something you would be interested in? I can write better code if that's the case :)