### PR TITLE
Let wait: and wait_until: accept symbols and zero-arity lambdas

### DIFF
--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -27,14 +27,12 @@ module ActiveJob::Performs
 
     def normalize_wait(value)
       case value
-      when Symbol then ->(record) { record.public_send(value) }
-      when Proc   then normalize_callable(value)
-      else value.respond_to?(:call) ? normalize_callable(value) : proc { value }
+      when Symbol then value.to_proc
+      when Proc
+        value.arity.zero? ? proc { value.call } : value
+      else
+        proc { value }
       end
-    end
-
-    def normalize_callable(value)
-      value.arity == 0 ? ->(_) { value.call } : value
     end
   end
 

--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -8,11 +8,11 @@ module ActiveJob::Performs
     attr_reader :wait, :wait_until
 
     def wait=(value)
-      @wait = value.respond_to?(:call) ? value : proc { value }
+      @wait = normalize_wait(value)
     end
 
     def wait_until=(value)
-      @wait_until = value.respond_to?(:call) ? value : proc { value }
+      @wait_until = normalize_wait(value)
     end
 
     def scoped_by_wait(record)
@@ -21,6 +21,20 @@ module ActiveJob::Performs
       else
         self
       end
+    end
+
+    private
+
+    def normalize_wait(value)
+      case value
+      when Symbol then ->(record) { record.public_send(value) }
+      when Proc   then normalize_callable(value)
+      else value.respond_to?(:call) ? normalize_callable(value) : proc { value }
+      end
+    end
+
+    def normalize_callable(value)
+      value.arity == 0 ? ->(_) { value.call } : value
     end
   end
 

--- a/test/active_job/test_performs.rb
+++ b/test/active_job/test_performs.rb
@@ -73,6 +73,30 @@ class ActiveJob::TestPerforms < ActiveSupport::TestCase
     end
   end
 
+  test "wait with symbol calls instance method for duration" do
+    assert_enqueued_with job: Post::Publisher::CooldownJob, args: [ @publisher ], at: 10.minutes.from_now do
+      @publisher.cooldown_later
+    end
+  end
+
+  test "wait with zero-arity lambda" do
+    assert_enqueued_with job: Post::Publisher::ScheduleCheckJob, args: [ @publisher ], at: 30.minutes.from_now do
+      @publisher.schedule_check_later
+    end
+  end
+
+  test "wait_until with symbol calls instance method for timestamp" do
+    assert_enqueued_with job: Post::Publisher::DeadlineBoostJob, args: [ @publisher ], at: DateTime.tomorrow.noon do
+      @publisher.deadline_boost_later!
+    end
+  end
+
+  test "wait_until with zero-arity lambda" do
+    assert_enqueued_with job: Post::Publisher::GlobalReminderJob, args: [ @publisher ], at: DateTime.tomorrow.noon do
+      @publisher.global_reminder_later
+    end
+  end
+
   test "allows overriding later methods with conditions and call super" do
     @publisher.skip_publish_later = true
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,8 +60,20 @@ class Post::Publisher < Base
 
   performs :retract, wait: 5.minutes, queue_adapter: :inline
   performs :social_media_boost!, wait_until: -> publisher { publisher.next_funnel_step_happens_at }
+  performs :cooldown, wait: :cooldown_duration
+  performs :schedule_check, wait: -> { 30.minutes }
+  performs :deadline_boost!, wait_until: :next_deadline
+  performs :global_reminder, wait_until: -> { DateTime.tomorrow.noon }
 
   def next_funnel_step_happens_at
+    DateTime.tomorrow.noon
+  end
+
+  def cooldown_duration
+    10.minutes
+  end
+
+  def next_deadline
     DateTime.tomorrow.noon
   end
 
@@ -78,6 +90,11 @@ class Post::Publisher < Base
   def social_media_boost!
     puts "social media soooo boosted"
   end
+
+  def cooldown = nil
+  def schedule_check = nil
+  def deadline_boost! = nil
+  def global_reminder = nil
 
   private performs def private_method
     puts __method__


### PR DESCRIPTION
- Adds a private `normalize_wait` method to the `Waiting` module that normalizes `wait:` and `wait_until:` values at assignment time
- **Symbols** are wrapped to call `public_send` on the record: `wait: :cooldown_duration` calls `record.cooldown_duration`
- **Zero-arity lambdas** are wrapped to ignore the record argument: `wait: -> { Setting.delay }` works without a throwaway `(_)` parameter
- Other callables (`Method` objects, etc.) are arity-checked the same way
- Static values (`wait: 5.minutes`) behave exactly as before
- All normalization happens at assignment time in a single `normalize_wait` method
- `scoped_by_wait` is unchanged

Builds on the discussion in #25 by @claudiob, extending the symbol support to also handle zero-arity lambdas.

### Before
```ruby
  performs :send_offer, wait_until: ->(nomination) { nomination.earliest_operating_time }
  performs :inquire_schedule, wait: ->(_) { Setting.hours_before_schedule_request.hours }
```
###  After
```ruby
  performs :send_offer, wait_until: :earliest_operating_time
  performs :inquire_schedule, wait: -> { Setting.hours_before_schedule_request.hours }
```