### PR TITLE
scope `Job` class definition to our namespace and not Object

### DIFF
--- a/lib/active_job/performs.rb
+++ b/lib/active_job/performs.rb
@@ -72,7 +72,7 @@ module ActiveJob::Performs
 
   private
     def safe_define(name)
-      name.safe_constantize || const_set(name, Class.new(yield))
+      const_defined?(name, false) ? const_get(name, false) : const_set(name, Class.new(yield))
     end
 
     def apply_performs_to(job, **configs, &block)

--- a/test/active_job/active_record/test_performs.rb
+++ b/test/active_job/active_record/test_performs.rb
@@ -4,6 +4,11 @@ module ActiveJob::ActiveRecord; end
 class ActiveJob::ActiveRecord::TestPerforms < ActiveSupport::TestCase
   setup { @invoice = Invoice.create! }
 
+  test "general job class definition" do
+    assert defined?(ApplicationRecord::Job)
+    assert defined?(Invoice::Job)
+  end
+
   test "touch_later" do
     assert_changes -> { @invoice.reload.updated_at } do
       assert_performed_with job: ApplicationRecord::TouchJob, args: [@invoice] do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,9 @@ require "active_record"
 require "debug"
 require "minitest/autorun"
 
+# We shouldn't generate the wrapping shared config Job at the top-level.
+class Job; end
+
 class ApplicationJob < ActiveJob::Base; end
 
 GlobalID.app = :performs


### PR DESCRIPTION
previously we'd locate a top-level `class Job; end` class in `safe_define` when calling `safe_constantize`. (we would correctly define the job within the class and not at the top-level.)

instead we have to use `const_defined?` and `const_get` with the "obj" parameter set to false so we don't cascade and check in `Object` where all top-level constants reside.

fixes https://github.com/kaspth/active_job-performs/issues/26